### PR TITLE
Group hierarchy feat

### DIFF
--- a/login/models.py
+++ b/login/models.py
@@ -33,7 +33,7 @@ class GroupProfile(models.Model):
                                  on_delete=models.CASCADE)
 
     description = models.CharField(max_length=100, blank=True, null=True)
-    level = models.PositiveIntegerField(validators=[MinValueValidator(1)])
+    level = models.PositiveIntegerField(validators=[MinValueValidator(1)], default=10)
 
     def get_absolute_url(self):
         return reverse('login:group_detail', kwargs={'pk': self.group.id})

--- a/login/models.py
+++ b/login/models.py
@@ -26,7 +26,6 @@ class UserProfile(models.Model):
 
 
 # GroupProfile
-# TODO: Add priority for sorting groups
 
 class GroupProfile(models.Model):
     group = models.OneToOneField(Group,

--- a/login/models.py
+++ b/login/models.py
@@ -42,7 +42,6 @@ class GroupProfile(models.Model):
 
     class Meta:
         indexes = [models.Index(fields=['priority'])]
-        ordering = ['priority']
 
 
 # Group Ambulance and Hospital Permissions

--- a/login/models.py
+++ b/login/models.py
@@ -41,7 +41,7 @@ class GroupProfile(models.Model):
         return '{}: description = {}'.format(self.group, self.description)
 
     class Meta:
-        indexes = []
+        indexes = [models.Index(fields=['priority'])]
         ordering = ['priority']
 
 

--- a/login/models.py
+++ b/login/models.py
@@ -2,6 +2,7 @@ from django.contrib.gis.db import models
 
 from django.contrib.auth.models import User
 from django.contrib.auth.models import Group
+from django.core.validators import MinValueValidator
 from django.urls import reverse
 
 from ambulance.models import Ambulance
@@ -32,6 +33,7 @@ class GroupProfile(models.Model):
                                  on_delete=models.CASCADE)
 
     description = models.CharField(max_length=100, blank=True, null=True)
+    level = models.PositiveIntegerField(validators=[MinValueValidator(1)])
 
     def get_absolute_url(self):
         return reverse('login:group_detail', kwargs={'pk': self.group.id})

--- a/login/models.py
+++ b/login/models.py
@@ -33,7 +33,11 @@ class GroupProfile(models.Model):
                                  on_delete=models.CASCADE)
 
     description = models.CharField(max_length=100, blank=True, null=True)
+<<<<<<< HEAD
     level = models.PositiveIntegerField(validators=[MinValueValidator(1)], default=10)
+=======
+    level = models.PositiveIntegerField(validators=[MinValueValidator(1)])
+>>>>>>> Added level field to group permissions
 
     def get_absolute_url(self):
         return reverse('login:group_detail', kwargs={'pk': self.group.id})

--- a/login/models.py
+++ b/login/models.py
@@ -41,8 +41,8 @@ class GroupProfile(models.Model):
     def __str__(self):
         return '{}: description = {}'.format(self.group, self.description)
 
-    # class Meta:
-    #     ordering = ['level']
+    class Meta:
+        ordering = ['level']
 
 
 # Group Ambulance and Hospital Permissions

--- a/login/models.py
+++ b/login/models.py
@@ -42,7 +42,7 @@ class GroupProfile(models.Model):
         return '{}: description = {}'.format(self.group, self.description)
 
     class Meta:
-        order_with_respect_to = 'level'
+        ordering = ['level']
 
 
 # Group Ambulance and Hospital Permissions

--- a/login/models.py
+++ b/login/models.py
@@ -41,6 +41,9 @@ class GroupProfile(models.Model):
     def __str__(self):
         return '{}: description = {}'.format(self.group, self.description)
 
+    class Meta:
+        order_with_respect_to = 'level'
+
 
 # Group Ambulance and Hospital Permissions
 

--- a/login/models.py
+++ b/login/models.py
@@ -41,8 +41,8 @@ class GroupProfile(models.Model):
     def __str__(self):
         return '{}: description = {}'.format(self.group, self.description)
 
-    class Meta:
-        ordering = ['level']
+    # class Meta:
+    #     ordering = ['level']
 
 
 # Group Ambulance and Hospital Permissions

--- a/login/models.py
+++ b/login/models.py
@@ -33,11 +33,7 @@ class GroupProfile(models.Model):
                                  on_delete=models.CASCADE)
 
     description = models.CharField(max_length=100, blank=True, null=True)
-<<<<<<< HEAD
     level = models.PositiveIntegerField(validators=[MinValueValidator(1)], default=10)
-=======
-    level = models.PositiveIntegerField(validators=[MinValueValidator(1)])
->>>>>>> Added level field to group permissions
 
     def get_absolute_url(self):
         return reverse('login:group_detail', kwargs={'pk': self.group.id})

--- a/login/models.py
+++ b/login/models.py
@@ -41,6 +41,7 @@ class GroupProfile(models.Model):
         return '{}: description = {}'.format(self.group, self.description)
 
     class Meta:
+        indexes = []
         ordering = ['priority']
 
 

--- a/login/models.py
+++ b/login/models.py
@@ -32,7 +32,7 @@ class GroupProfile(models.Model):
                                  on_delete=models.CASCADE)
 
     description = models.CharField(max_length=100, blank=True, null=True)
-    level = models.PositiveIntegerField(validators=[MinValueValidator(1)], default=10)
+    priority = models.PositiveIntegerField(validators=[MinValueValidator(1)], default=10)
 
     def get_absolute_url(self):
         return reverse('login:group_detail', kwargs={'pk': self.group.id})
@@ -41,7 +41,7 @@ class GroupProfile(models.Model):
         return '{}: description = {}'.format(self.group, self.description)
 
     class Meta:
-        ordering = ['level']
+        ordering = ['priority']
 
 
 # Group Ambulance and Hospital Permissions

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -75,8 +75,7 @@ class Permissions:
                         # e.g.: objs = group.groupambulancepermission_set.all()
                         objs = getattr(group, 'group' + object_field + 'permission_set').all()
 
-                        for e in objs:
-                            print(e)
+                        print(objs)
 
                         # e.g.: self.ambulances.update({e.ambulance_id: {...} for e in objs})
                         getattr(self, profile_field).update({

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -70,7 +70,7 @@ class Permissions:
             else:
 
                 # regular users, loop through groups
-                for group in user.groups.all().order_by('groupprofile__priority'):
+                for group in user.groups.all().order_by('-groupprofile__priority'):
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
 
                         # e.g.: objs = group.groupambulancepermission_set.all()

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -74,6 +74,10 @@ class Permissions:
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
                         # e.g.: objs = group.groupambulancepermission_set.all()
                         objs = getattr(group, 'group' + object_field + 'permission_set').all()
+
+                        for e in objs:
+                            print(e)
+
                         # e.g.: self.ambulances.update({e.ambulance_id: {...} for e in objs})
                         getattr(self, profile_field).update({
                             getattr(e, object_field + '_id'): {

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -71,7 +71,6 @@ class Permissions:
 
                 # regular users, loop through groups
                 for group in user.groups.all().order_by('groupprofile__priority'):
-                    print(group)
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
 
                         # e.g.: objs = group.groupambulancepermission_set.all()

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -7,7 +7,7 @@ from hospital.models import Hospital
 
 logger = logging.getLogger(__name__)
 
-PERMISSION_CACHE_SIZE = 1
+PERMISSION_CACHE_SIZE = 10
 
 
 @lru_cache(maxsize=PERMISSION_CACHE_SIZE)

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -7,7 +7,7 @@ from hospital.models import Hospital
 
 logger = logging.getLogger(__name__)
 
-PERMISSION_CACHE_SIZE = 10
+PERMISSION_CACHE_SIZE = 1
 
 
 @lru_cache(maxsize=PERMISSION_CACHE_SIZE)
@@ -71,6 +71,7 @@ class Permissions:
 
                 # regular users, loop through groups
                 for group in user.groups.all():
+                    print(group)
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
 
                         # e.g.: objs = group.groupambulancepermission_set.all()

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -69,8 +69,6 @@ class Permissions:
 
             else:
 
-                print(user.groups.all())
-
                 # regular users, loop through groups
                 for group in user.groups.all():
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -71,6 +71,7 @@ class Permissions:
 
                 # regular users, loop through groups
                 for group in user.groups.all().order_by('groupprofile__priority'):
+                    print(group)
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
 
                         # e.g.: objs = group.groupambulancepermission_set.all()

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -70,8 +70,7 @@ class Permissions:
             else:
 
                 # regular users, loop through groups
-                for group in user.groups.all():
-                    print(group)
+                for group in user.groups.all().order_by('groupprofile__priority'):
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
 
                         # e.g.: objs = group.groupambulancepermission_set.all()

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -69,13 +69,14 @@ class Permissions:
 
             else:
 
+                print(user.groups.all())
+
                 # regular users, loop through groups
                 for group in user.groups.all():
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
-                        # e.g.: objs = group.groupambulancepermission_set.all()
-                        objs = getattr(group, 'group' + object_field + 'permission_set').all().order_by('level')
 
-                        print(objs)
+                        # e.g.: objs = group.groupambulancepermission_set.all()
+                        objs = getattr(group, 'group' + object_field + 'permission_set').all()
 
                         # e.g.: self.ambulances.update({e.ambulance_id: {...} for e in objs})
                         getattr(self, profile_field).update({

--- a/login/permissions.py
+++ b/login/permissions.py
@@ -73,7 +73,7 @@ class Permissions:
                 for group in user.groups.all():
                     for (profile_field, object_field) in zip(self.profile_fields, self.object_fields):
                         # e.g.: objs = group.groupambulancepermission_set.all()
-                        objs = getattr(group, 'group' + object_field + 'permission_set').all()
+                        objs = getattr(group, 'group' + object_field + 'permission_set').all().order_by('level')
 
                         print(objs)
 

--- a/login/views.py
+++ b/login/views.py
@@ -75,7 +75,7 @@ class LogoutView(auth_views.LogoutView):
 class GroupAdminListView(ListView):
     model = Group
     template_name = 'login/group_list.html'
-    ordering = ['name']
+    ordering = ['groupprofile__priority', 'name']
 
 
 class GroupAdminDetailView(DetailView):

--- a/login/views.py
+++ b/login/views.py
@@ -75,7 +75,7 @@ class LogoutView(auth_views.LogoutView):
 class GroupAdminListView(ListView):
     model = Group
     template_name = 'login/group_list.html'
-    ordering = ['groupprofile__priority', 'name']
+    ordering = ['-groupprofile__priority', 'name']
 
 
 class GroupAdminDetailView(DetailView):

--- a/templates/login/group_detail.html
+++ b/templates/login/group_detail.html
@@ -22,7 +22,7 @@
             </p>
 
             <p>
-                <strong>Level</strong>
+                <strong>Priority</strong>
                 {{ group.groupprofile.priority }}
             </p>
 

--- a/templates/login/group_detail.html
+++ b/templates/login/group_detail.html
@@ -21,6 +21,11 @@
                 {{ group.groupprofile.description }}
             </p>
 
+            <p>
+                <strong>Level</strong>
+                {{ group.groupprofile.level }}
+            </p>
+
         </div>
     </div>
 

--- a/templates/login/group_detail.html
+++ b/templates/login/group_detail.html
@@ -23,7 +23,7 @@
 
             <p>
                 <strong>Level</strong>
-                {{ group.groupprofile.level }}
+                {{ group.groupprofile.priority }}
             </p>
 
         </div>

--- a/templates/login/group_list.html
+++ b/templates/login/group_list.html
@@ -18,6 +18,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
+                    <th>Level</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -28,6 +29,9 @@
                     </td>
                     <td>
                         {{ group.groupprofile.description }}
+                    </td>
+                    <td>
+                        {{ group.groupprofile.level }}
                     </td>
                 </tr>
                 {% endfor %}

--- a/templates/login/group_list.html
+++ b/templates/login/group_list.html
@@ -18,7 +18,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
-                    <th>Level</th>
+                    <th>Priority</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -31,7 +31,7 @@
                         {{ group.groupprofile.description }}
                     </td>
                     <td>
-                        {{ group.groupprofile.level }}
+                        {{ group.groupprofile.priority }}
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
**Features**
- Adds group priority field (default 10 currently) (larger priorities take precedence)
- Adds indexing to group priority field
- Priority added to HTML page on groups
- HTML groups page sorted by priority then name
- Priority sort added to permissions.py

**Outstanding issues**

- I'm not sure if resetting the cache is working. I could not get it to work so I had to just set the cache size to 1 and make two users.
- When a user is in two groups and the admin changes the priority such that the previously lower priority group is now higher, the user does not observe potential changes immediately on the website (even though I've confirmed the priorities are actually sorting properly in permissions.py) - this bug is super weird