### PR TITLE
Adding ambulance equipment api

### DIFF
--- a/ambulance/viewsets.py
+++ b/ambulance/viewsets.py
@@ -20,7 +20,7 @@ from .serializers import LocationSerializer, AmbulanceSerializer, AmbulanceUpdat
 
 from equipment.models import EquipmentItem
 from equipment.serializers import EquipmentItemSerializer
-from equipment.viewsets import EquipmentViewSet
+from equipment.viewsets import EquipmentItemViewSet
 import logging
 logger = logging.getLogger(__name__)
 

--- a/ambulance/viewsets.py
+++ b/ambulance/viewsets.py
@@ -20,7 +20,7 @@ from .serializers import LocationSerializer, AmbulanceSerializer, AmbulanceUpdat
 
 from equipment.models import EquipmentItem
 from equipment.serializers import EquipmentItemSerializer
-
+from equipment.viewsets import EquipmentViewSet
 import logging
 logger = logging.getLogger(__name__)
 

--- a/ambulance/viewsets.py
+++ b/ambulance/viewsets.py
@@ -18,11 +18,41 @@ from .models import Location, Ambulance, LocationType, Call, AmbulanceUpdate, Am
 from .serializers import LocationSerializer, AmbulanceSerializer, AmbulanceUpdateSerializer, CallSerializer, \
     CallPriorityCodeSerializer, CallPriorityClassificationSerializer, CallRadioCodeSerializer
 
+from equipment.models import EquipmentItem
+from equipment.serializers import EquipmentItemSerializer
+
 import logging
 logger = logging.getLogger(__name__)
 
 
 # Django REST Framework Viewsets
+class AmbulanceEquipmentItemViewSet(EquipmentItemViewSet):
+    """
+    API endpoint for manipulating ambulance equipment.
+
+    list:
+    Retrieve list of equipment.
+
+    retrieve:
+    Retrieve an existing equipment instance.
+
+    update:
+    Update existing equipment instance.
+
+    partial_update:
+    Partially update existing equipment instance.
+    """
+    queryset = EquipmentItem.objects.all()
+
+    serializer_class = EquipmentItemSerializer
+    lookup_field = 'equipment_id'
+    def get_queryset(self):
+        
+        ambulance_id = int(self.kwargs['ambulance_id'])
+        ambulance = Ambulance.objects.get(id=ambulance_id)
+        equipmentholder_id = ambulance.equipmentholder.id
+        return super().get_queryset(equipmentholder_id)
+        
 
 class AmbulancePageNumberPagination(PageNumberPagination):
     page_size_query_param = 'page_size'

--- a/emstrack/urls.py
+++ b/emstrack/urls.py
@@ -10,8 +10,7 @@ from rest_framework_swagger.views import get_swagger_view
 from login.viewsets import ProfileViewSet, ClientViewSet
 from login.views import PasswordView, SettingsView, VersionView
 
-from ambulance.viewsets import AmbulanceViewSet, LocationViewSet, LocationTypeViewSet, CallViewSet, CallPriorityViewSet, \
-    CallRadioViewSet
+from ambulance.viewsets import AmbulanceEquipmentItemViewSet, AmbulanceViewSet, CallPriorityViewSet, CallRadioViewSet, CallViewSet, LocationTypeViewSet, LocationViewSet
 
 from hospital.viewsets import HospitalViewSet
 from equipment.viewsets import EquipmentItemViewSet, EquipmentViewSet
@@ -29,6 +28,10 @@ router.register(r'user',
 router.register(r'ambulance',
                 AmbulanceViewSet,
                 basename='api-ambulance')
+
+router.register(r'ambulance/(?P<ambulance_id>[0-9]+)/equipment',
+                AmbulanceEquipmentItemViewSet,
+                basename='api-ambulance-equipment')
 
 router.register(r'location',
                 LocationViewSet,

--- a/equipment/viewsets.py
+++ b/equipment/viewsets.py
@@ -37,7 +37,7 @@ class EquipmentItemViewSet(mixins.ListModelMixin,
     lookup_field = 'equipment_id'
 
     # make sure both fields are looked up
-    def get_queryset(self):
+    def get_queryset(self, equipmentholder_id=None):
 
         # retrieve user
         user = self.request.user
@@ -47,7 +47,8 @@ class EquipmentItemViewSet(mixins.ListModelMixin,
             raise PermissionDenied()
         
         # retrieve id
-        equipmentholder_id = int(self.kwargs['equipmentholder_id'])
+        if equipmentholder_id is None:
+            equipmentholder_id = int(self.kwargs['equipmentholder_id'])
         logger.debug('kwargs = {}'.format(self.kwargs))
 
         try:


### PR DESCRIPTION
Ambulance Equipment api has never actually been done.
now the new path /api/ambulance/:id/equipment returns equipment of the ambulance with id:id