### PR TITLE
Adding api functionality for hospital

### DIFF
--- a/emstrack/urls.py
+++ b/emstrack/urls.py
@@ -12,7 +12,7 @@ from login.views import PasswordView, SettingsView, VersionView
 
 from ambulance.viewsets import AmbulanceEquipmentItemViewSet, AmbulanceViewSet, CallPriorityViewSet, CallRadioViewSet, CallViewSet, LocationTypeViewSet, LocationViewSet
 
-from hospital.viewsets import HospitalViewSet
+from hospital.viewsets import HospitalViewSet, HospitalEquipmentItemViewSet
 from equipment.viewsets import EquipmentItemViewSet, EquipmentViewSet
 
 from .views import IndexView
@@ -44,6 +44,10 @@ router.register(r'location/(?P<type>.+)',
 router.register(r'hospital',
                 HospitalViewSet,
                 basename='api-hospital')
+                
+router.register(r'hospital/(?P<hospital_id>[0-9]+)/equipment',
+                HospitalEquipmentItemViewSet,
+                basename='api-hospital-equipment')
 
 router.register(r'equipment/(?P<equipmentholder_id>[0-9]+)/item',
                 EquipmentItemViewSet,

--- a/equipment/viewsets.py
+++ b/equipment/viewsets.py
@@ -7,7 +7,8 @@ from rest_framework.response import Response
 from emstrack.mixins import UpdateModelUpdateByMixin, BasePermissionMixin
 from equipment.models import EquipmentItem, EquipmentHolder, Equipment
 from equipment.serializers import EquipmentItemSerializer, EquipmentSerializer
-from hospital.viewsets import logger
+import logging
+logger = logging.getLogger(__name__)
 from login.permissions import get_permissions
 
 

--- a/hospital/viewsets.py
+++ b/hospital/viewsets.py
@@ -23,7 +23,7 @@ from equipment.serializers import EquipmentItemSerializer
 # Django REST Framework Viewsets
 class HospitalEquipmentItemViewSet(EquipmentItemViewSet):
     """
-    API endpoint for manipulating ambulance equipment.
+    API endpoint for manipulating hospital equipment.
 
     list:
     Retrieve list of equipment.

--- a/hospital/viewsets.py
+++ b/hospital/viewsets.py
@@ -15,8 +15,38 @@ from equipment.serializers import EquipmentSerializer
 
 logger = logging.getLogger(__name__)
 
+from equipment.viewsets import EquipmentItemViewSet
+from equipment.models import EquipmentItem
+from equipment.serializers import EquipmentItemSerializer
+    
 
 # Django REST Framework Viewsets
+class HospitalEquipmentItemViewSet(EquipmentItemViewSet):
+    """
+    API endpoint for manipulating ambulance equipment.
+
+    list:
+    Retrieve list of equipment.
+
+    retrieve:
+    Retrieve an existing equipment instance.
+
+    update:
+    Update existing equipment instance.
+
+    partial_update:
+    Partially update existing equipment instance.
+    """
+    queryset = EquipmentItem.objects.all()
+
+    serializer_class = EquipmentItemSerializer
+    lookup_field = 'equipment_id'
+    def get_queryset(self):
+        
+        hospital_id = int(self.kwargs['hospital_id'])
+        hospital = Hospital.objects.get(id=hospital_id)
+        equipmentholder_id = hospital.equipmentholder.id
+        return super().get_queryset(equipmentholder_id)
 
 
 # Hospital viewset


### PR DESCRIPTION
importing logger from equipment viewset created circular import resulting in error. 
For fix changed so that equipment viewset imports a separate logger.

Hospital Equipment Api was missing so added the functionality.