### PR TITLE
Swagger fixed

### DIFF
--- a/emstrack/settings.py
+++ b/emstrack/settings.py
@@ -190,6 +190,7 @@ MQTT = {
 
 # REST Framework
 REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',


### PR DESCRIPTION
Swagger was not working because of version difference.
Looking below github issue page, I added 

'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'


https://github.com/encode/django-rest-framework/issues/6809